### PR TITLE
Stop marzban-node installer log tail to avoid hanging and extend expect timeout

### DIFF
--- a/marz-node-script.sh
+++ b/marz-node-script.sh
@@ -552,7 +552,8 @@ export NODE_NAME SERVICE_PORT API_PORT
 
 expect << 'EOF'
 log_user 1
-set timeout 600
+set timeout 900
+set logs_tail_stopped 0
 
 spawn ./marzban-node.sh @ install --name $env(NODE_NAME)
 
@@ -567,6 +568,23 @@ expect {
   -re "Do you want to use REST protocol" { send -- "y\r"; exp_continue }
   -re "Enter the SERVICE_PORT" { send -- "$env(SERVICE_PORT)\r"; exp_continue }
   -re "Enter the XRAY_API_PORT" { send -- "$env(API_PORT)\r"; exp_continue }
+  -re "(Node service running on|Uvicorn running on|Application startup complete)" {
+      if {$logs_tail_stopped == 0} {
+        # marzban-node installer may switch to `docker logs -f` and never return.
+        # Stop the log tail so the parent script can continue.
+        send -- "\003"
+        set logs_tail_stopped 1
+      }
+      exp_continue
+  }
+  timeout {
+      if {$logs_tail_stopped == 0} {
+        send -- "\003"
+        set logs_tail_stopped 1
+        exp_continue
+      }
+      send_user "\n[WARNING] Timeout while waiting marzban-node installer to finish. Continuing...\n"
+  }
   eof
 }
 EOF


### PR DESCRIPTION
### Motivation
- Prevent the `marzban-node` installer from blocking the parent script when it switches to a `docker logs -f` tail by stopping the log tail once the application shows it started. 
- Allow longer install runs by increasing the `expect` timeout.

### Description
- Increase `expect` `timeout` from `600` to `900`.
- Add a `logs_tail_stopped` flag and new `expect` pattern matching `(Node service running on|Uvicorn running on|Application startup complete)` that sends `Ctrl-C` (`\003`) to stop a lingering log tail and continue the installer flow.
- Add a `timeout` branch that sends `Ctrl-C` once and prints a warning before continuing if the installer times out while still tailing logs.
- Preserve existing interaction branches for certificate paste and port prompts.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5c8cbfb0083319b3e71f7dcb46477)