### PR TITLE
Inject XRAY_EXECUTABLE_PATH into generated docker-compose.yml

### DIFF
--- a/marz-node-script.sh
+++ b/marz-node-script.sh
@@ -599,6 +599,15 @@ chmod 755 /var/lib/marzban/log
 chmod 644 /var/lib/marzban/log/access.log
 
 if [[ -f "${DOCKER_COMPOSE_FILE}" ]]; then
+  # добавим XRAY_EXECUTABLE_PATH в environment, если его ещё нет
+  if ! grep -q "XRAY_EXECUTABLE_PATH:" "${DOCKER_COMPOSE_FILE}"; then
+    if grep -qE '^\s*environment:\s*$' "${DOCKER_COMPOSE_FILE}"; then
+      sed -i '/^\s*environment:\s*$/a\      XRAY_EXECUTABLE_PATH: /var/lib/marzban-node/xray-core/xray' "${DOCKER_COMPOSE_FILE}"
+    else
+      sed -i '0,/^\s*network_mode:\s*/s//&\n    environment:\n      XRAY_EXECUTABLE_PATH: \/var\/lib\/marzban-node\/xray-core\/xray\n/' "${DOCKER_COMPOSE_FILE}"
+    fi
+  fi
+
   # добавим volume, если его ещё нет
   if ! grep -q "/var/lib/marzban/log:/var/lib/marzban/log" "${DOCKER_COMPOSE_FILE}"; then
     # если volumes: есть — допишем; если нет — создадим в сервисе


### PR DESCRIPTION
### Motivation
- Ensure the node's generated `/opt/${NODE_NAME}/docker-compose.yml` contains the `XRAY_EXECUTABLE_PATH` environment variable so the container can find the xray binary.

### Description
- Update `marz-node-script.sh` to detect if `/opt/${NODE_NAME}/docker-compose.yml` exists and add `XRAY_EXECUTABLE_PATH: /var/lib/marzban-node/xray-core/xray` when it is missing.
- If an `environment:` block exists in the compose file the variable is appended there, otherwise an `environment:` block is inserted after `network_mode:` with the required variable.
- Existing log volume patching and the subsequent `docker compose` restart behavior are left unchanged.

### Testing
- Performed a syntax check with `bash -n marz-node-script.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dd6d7ed08331b7b73f942cf7468b)